### PR TITLE
feat: configure sso Richie and LMS and add demo and reindex as commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Other are per site, replace the {site} with the name of your site:
 - `RICHIE_{site}_EDX_JS_BACKEND` - (default: `openedx-hawthorn`)
 - `RICHIE_{site}_AUTHENTICATION_BASE_URL` - (default: `https://{{ LMS_HOST }}`)
 - `RICHIE_{site}_AUTHENTICATION_BACKEND` - (default: `openedx-hawthorn`)
+- `RICHIE_{site}_OAUTH2_CLIENT_AUTHORIZED_PATH` - (default: `None`)
 
 If you need to completely customize the production environment, you can use the Tutor patch `richie-{{site}}-production-env`.
 

--- a/tutorrichiesitefactory/patches_per_site/caddyfile-lms
+++ b/tutorrichiesitefactory/patches_per_site/caddyfile-lms
@@ -1,0 +1,10 @@
+# On LMS, redirect the path "/richie_{{site}}" to the corresponding Richie site instance
+@richie_{{site}} {
+    path /richie-{{site}}/*
+}
+handle @richie_{{site}} {
+    route {
+        uri strip_prefix /richie-{{site}}
+        redir {% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ RICHIE_{{site}}_HOST }}{uri}
+    }
+}

--- a/tutorrichiesitefactory/plugin.py
+++ b/tutorrichiesitefactory/plugin.py
@@ -239,5 +239,38 @@ def register_cli_do_commands(site: str):
         ]
     hooks.Filters.CLI_DO_COMMANDS.add_item(richie_init)
 
+    @click.command(name=f"richie-{site}-create-demo-site")
+    def create_demo_site() -> list[tuple[str, str]]:
+        """
+        Job to create a demo site.
+        """
+        return [
+            (
+                f"richie-{site}",
+                f"echo 'Initialize richie-{site} with a minimum site structure...' && "
+                # "python manage.py flush --force && "
+                "python manage.py create_demo_site --force && "
+                "python manage.py bootstrap_elasticsearch && "
+                "echo 'Done!';",
+            ),
+        ]
+    hooks.Filters.CLI_DO_COMMANDS.add_item(create_demo_site)
+
+    @click.command(name=f"richie-{site}-bootstrap-elasticsearch")
+    def bootstrap_elasticsearch() -> list[tuple[str, str]]:
+        """
+        Job to reindex Richie site.
+        """
+        return [
+            (
+                f"richie-{site}",
+                f"echo 'Initialize richie-{site} with a minimum site structure...' && "
+                "python manage.py bootstrap_elasticsearch && "
+                "echo 'Done!';",
+            ),
+        ]
+    hooks.Filters.CLI_DO_COMMANDS.add_item(bootstrap_elasticsearch)
+
+
 for site in richie_sites:
     register_cli_do_commands(site)

--- a/tutorrichiesitefactory/plugin.py
+++ b/tutorrichiesitefactory/plugin.py
@@ -45,7 +45,7 @@ for site in richie_sites:
             f"RICHIE_{site}_DB_NAME": f"richie_{site}",
             f"RICHIE_{site}_DB_PORT": "{{ MYSQL_PORT }}",
             f"RICHIE_{site}_DB_USER": f"richie_{site}",
-            f"RICHIE_{site}_MYSQL_INIT": "true",
+            f"RICHIE_{site}_MYSQL_INIT": True,
             f"RICHIE_{site}_MYSQL_ROOT_USERNAME": "{{ RICHIE_MYSQL_ROOT_USERNAME }}",
             f"RICHIE_{site}_MYSQL_ROOT_PASSWORD": "{{ RICHIE_MYSQL_ROOT_PASSWORD }}",
             f"RICHIE_{site}_ELASTICSEARCH_HOST": "{{ ELASTICSEARCH_HOST }}",

--- a/tutorrichiesitefactory/templates/richie/tasks/lms/init
+++ b/tutorrichiesitefactory/templates/richie/tasks/lms/init
@@ -1,7 +1,20 @@
+# Initialize Richie {{site}} SSO on Open edX LMS
+{%- if RICHIE_{{site}}_OAUTH2_CLIENT_AUTHORIZED_PATH %}
+./manage.py lms manage_user richie-{{site}} richie-{{site}}@openedx --unusable-password
 ./manage.py lms create_dot_application \
     --grant-type authorization-code \
-    --redirect-uris "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ RICHIE_{{site}}_HOST }}/oauth-authorized/openedxsso" \
+    --redirect-uris "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ RICHIE_{{site}}_HOST }}{{ RICHIE_{{site}}_OAUTH2_CLIENT_AUTHORIZED_PATH }}" \
     --client-id {{ RICHIE_{{site}}_OAUTH2_CLIENT_ID }} \
     --client-secret {{ RICHIE_{{site}}_OAUTH2_CLIENT_SECRET }} \
-    --scopes "user_id" \
-    sso-richie-site-factory richie-site-factory
+    --scopes user_id \
+    --skip-authorization \
+    --update richie-{{site}}-sso richie-{{site}}
+./manage.py lms create_dot_application \
+    --grant-type authorization-code \
+    --redirect-uris "http://{{ RICHIE_{{site}}_HOST }}{{ RICHIE_{{site}}_OAUTH2_CLIENT_AUTHORIZED_PATH }}" \
+    --client-id {{ RICHIE_{{site}}_OAUTH2_CLIENT_ID_DEV }} \
+    --client-secret {{ RICHIE_{{site}}_OAUTH2_CLIENT_SECRET }} \
+    --scopes user_id \
+    --skip-authorization \
+    --update richie-{{site}}-sso-dev richie-{{site}}
+{%- endif %}

--- a/tutorrichiesitefactory/templates/richie/tasks/lms/init
+++ b/tutorrichiesitefactory/templates/richie/tasks/lms/init
@@ -1,0 +1,7 @@
+./manage.py lms create_dot_application \
+    --grant-type authorization-code \
+    --redirect-uris "{% if ENABLE_HTTPS %}https{% else %}http{% endif %}://{{ RICHIE_{{site}}_HOST }}/oauth-authorized/openedxsso" \
+    --client-id {{ RICHIE_{{site}}_OAUTH2_CLIENT_ID }} \
+    --client-secret {{ RICHIE_{{site}}_OAUTH2_CLIENT_SECRET }} \
+    --scopes "user_id" \
+    sso-richie-site-factory richie-site-factory


### PR DESCRIPTION
feat: configure sso Richie and LMS

Configures Single Sign On between Richie and LMS.
To activate configure `RICHIE_ {site}_OAUTH2_CLIENT_AUTHORIZED_PATH`.

---

feat: cli do commands for demo and reindex

Add Tutor command line do commands for:
- create demo site
- bootstrap elasticsearch